### PR TITLE
release 0.16.2 (#85)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.2] Q3 2023
+- added prerequisites to readme
+- downgraded tracing to 0.1.37
+- updated webpki to 0.22.2
+- fixed missing copy script for ssh tunnel setup
+- fixed file copy scripts to skip existing files
+
 ## [0.16.1] Q3 2023
 - updated openssl to 0.10.57
 - updated rustls-webpki to 0.100.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2262,7 +2262,7 @@ dependencies = [
 
 [[package]]
 name = "omnect-cli"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "actix",
  "actix-web",
@@ -3396,10 +3396,11 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.38"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9cf6a813d3f40c88b0b6b6f29a5c95c6cdbf97c1f9cc53fb820200f5ad814d"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
+ "cfg-if",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -3683,9 +3684,9 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.22.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0e74f82d49d545ad128049b7e88f6576df2da6b02e9ce565c6f533be576957e"
+checksum = "07ecc0cd7cac091bf682ec5efa18b1cff79d617b84181f38b3951dbe135f607f"
 dependencies = [
  "ring",
  "untrusted",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnect-cli"
-version = "0.16.1"
+version = "0.16.2"
 authors = ["omnect@conplement.de>"]
 edition = "2021"
 build = "src/build.rs"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ omnect-cli is a cli tool to manage your omnect-devices. It provides commands to 
 - SSH
   - Open an ssh tunnel on a device in the field to connect to it.
 
+# Prerequisites
+
+Depending on your intended use use you want to install the following packages.
+
+- openssh: For the `ssh` command.
+- docker: For the `file`, `iot-hub-device-update`, `identity` and `wifi` commands.
+
 # Download prebuild Docker image
 - login to azure docker registry either via admin user
     ```sh

--- a/backend/sh/copy_file_to_image.sh
+++ b/backend/sh/copy_file_to_image.sh
@@ -60,8 +60,8 @@ if [ "${p}" != "boot" ]; then
     e2cp ${i} /tmp/${uuid}/${p}.img:${o}
 else
     if [ ! -d $(dirname ${o}) ]; then
-        d_echo "mmd -i /tmp/${uuid}/${p}.img ::$(dirname ${o})"
-        mmd -i /tmp/${uuid}/${p}.img ::$(dirname ${o})
+        d_echo "mmd -D sS -i /tmp/${uuid}/${p}.img ::$(dirname ${o})"
+        mmd -D sS -i /tmp/${uuid}/${p}.img ::$(dirname ${o})
     fi
 
     d_echo "mcopy -o -i /tmp/${uuid}/${p}.img ${i} ::${o})"

--- a/backend/sh/set_ssh_tunnel_cert.sh
+++ b/backend/sh/set_ssh_tunnel_cert.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# include shared functions
+. /omnect-sh/functions
+
+d_echo ${0}
+
+function usage() {
+    echo "Usage: $0  -r root_cert -d device_id -w wic_image [-b output_bmap_file]" 1>&2; exit 1;
+}
+
+set -o errexit   # abort on nonzero exitstatus
+set -o pipefail  # don't hide errors within pipes
+
+while getopts "r:d:w:" opt; do
+    case "${opt}" in
+        r)
+            r=${OPTARG}
+            ;;
+        d)
+            d=${OPTARG}
+            ;;
+        w)
+            w=${OPTARG}
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+shift $((OPTIND-1))
+
+if [ -z "${r}" ] || [ -z "${d}" ] || [ -z "${w}" ]; then
+    usage
+fi
+
+d_echo "r = ${r}"
+d_echo "d = ${d}"
+d_echo "w = ${w}"
+
+[[ ! -f ${w} ]] && error "input device image not found"     && exit 1
+
+p=cert
+
+uuid_gen
+handle_partition_type
+read_in_partition
+
+echo "${d}" > /tmp/${uuid}/authorized_principals
+
+e2cp "${r}" /tmp/${uuid}/${p}.img:/ssh/root_ca
+e2cp /tmp/${uuid}/authorized_principals /tmp/${uuid}/${p}.img:/ssh/authorized_principals
+
+write_back_partition
+
+if [ "0" != "${b}0" ]; then
+    bmaptool create -o ${b} ${w}
+fi


### PR DESCRIPTION
* Skip primary and secondary name if exist

* cargo.toml: downgrade tracing 0.1.38 to 0.1.37

Fixes yanked version.

* cargo.toml: bump webpki 0.22.1 to 0.22.2

Fixes RUSTSEC-2023-0052.

* fix: add missing ssh tunnel script

* readme: add basic prerequisites section

* release 0.16.2

---------